### PR TITLE
Update the mru file using the BufEnter autocmd

### DIFF
--- a/plugin/mru.vim
+++ b/plugin/mru.vim
@@ -947,6 +947,9 @@ call s:MRU_LoadList()
 
 " MRU autocommands {{{1
 " Autocommands to update the most recently used files
+autocmd BufRead * call s:MRU_AddFile(expand('<abuf>'))
+autocmd BufNewFile * call s:MRU_AddFile(expand('<abuf>'))
+autocmd BufWritePost * call s:MRU_AddFile(expand('<abuf>'))
 autocmd BufEnter * call s:MRU_AddFile(expand('<abuf>'))
 
 " The ':vimgrep' command adds all the files searched to the buffer list.

--- a/plugin/mru.vim
+++ b/plugin/mru.vim
@@ -946,10 +946,8 @@ endfunc
 call s:MRU_LoadList()
 
 " MRU autocommands {{{1
-" Autocommands to detect the most recently used files
-autocmd BufRead * call s:MRU_AddFile(expand('<abuf>'))
-autocmd BufNewFile * call s:MRU_AddFile(expand('<abuf>'))
-autocmd BufWritePost * call s:MRU_AddFile(expand('<abuf>'))
+" Autocommands to update the most recently used files
+autocmd BufEnter * call s:MRU_AddFile(expand('<abuf>'))
 
 " The ':vimgrep' command adds all the files searched to the buffer list.
 " This also modifies the MRU list, even though the user didn't edit the


### PR DESCRIPTION
I personally find that updating the mru list based on the BufEnter event provides a much better user experience. I would like to know your thoughts on this.