### PR TITLE
FZF should respect the sorting of the MRU file (sorted by recency) while typing and refreshing the query results

### DIFF
--- a/plugin/mru.vim
+++ b/plugin/mru.vim
@@ -1035,6 +1035,7 @@ func s:MRU_FZF_Run() abort
     return
   endif
   call fzf#run(fzf#wrap({'source' : s:MRU_files,
+    \ 'options' : '--no-sort',
 	\ 'sink' : function('s:MRU_FZF_EditFile'),
 	\ 'down' : g:MRU_Window_Height}, 0))
 endfunc

--- a/plugin/mru.vim
+++ b/plugin/mru.vim
@@ -1036,8 +1036,8 @@ func s:MRU_FZF_Run() abort
   endif
   call fzf#run(fzf#wrap({'source' : s:MRU_files,
     \ 'options' : '--no-sort',
-	\ 'sink' : function('s:MRU_FZF_EditFile'),
-	\ 'down' : g:MRU_Window_Height}, 0))
+    \ 'sink' : function('s:MRU_FZF_EditFile'),
+    \ 'down' : g:MRU_Window_Height}, 0))
 endfunc
 command! -nargs=0 FZFMru call s:MRU_FZF_Run()
 


### PR DESCRIPTION
I noticed that when using the `:FZFMru`, the results will be displayed in alphabetical sorting while typing, hence the MRU file contents' sorting is disregarded/ignored.

For example, the `apps/backoffice/secure_api_endpoints/serializers.py` is more recent compared to `apps/common/api/serializers.py` when the `FZFMru` starts:
<img width="917" alt="Screen Shot 2021-11-13 at 4 54 39 AM" src="https://user-images.githubusercontent.com/4292088/141536739-d2bfddfe-3f79-4cdd-b5f8-25a086c776d1.png">
 
But when I type `serializers`, I expect that the same ordering is maintained, but it's being sorted alphabetically instead (default behavior of `fzf`).
<img width="743" alt="Screen Shot 2021-11-13 at 4 54 58 AM" src="https://user-images.githubusercontent.com/4292088/141536995-b4ddaf19-749b-435f-bd5d-b100174975ae.png">

Upon some digging, the fix is relatively simple, and just need to add the `--no-sort` option in the `fzf` command. Likewise, in the PR diff there are some changes in the tabs/spaces since the file uses tabs and my Neovim uses spaces. It still works as intended though.

BTW, thanks for this useful plugin. :)
