### PR TITLE
Keep alternate file when using current window

### DIFF
--- a/plugin/mru.vim
+++ b/plugin/mru.vim
@@ -474,14 +474,16 @@ func! s:MRU_Window_Edit_File(fname, multi, edit_type, open_type) abort
 	  exe 'sview ' . esc_fname
 	endif
       else
+	" When using the current window, keep the original alternate file to
+	" avoid switching to an empty MRU files buffer with CTRL-^ and friends
 	if a:edit_type ==# 'edit'
 	  if bufexists(esc_fname)
-	    exe 'buffer ' . esc_fname
+	    exe 'keepalt buffer ' . esc_fname
 	  else
-	    exe 'edit ' . esc_fname
+	    exe 'keepalt edit ' . esc_fname
 	  endif
 	else
-	  exe 'view ' . esc_fname
+	  exe 'keepalt view ' . esc_fname
 	endif
       endif
     endif


### PR DESCRIPTION
Update commands to use keepalt when MRU set to use the current window,
such that after opening and selecting a file from the MRU window, the
alternate file is the last edited file rather than the MRU files buffer.

The MRU files buffer is empty when loaded as the alternate file, so it
doesn't seem necessary to add a new configuration variable for this.