### PR TITLE
Tweak toggle and alt file behaviour when MRU set to use current window

### DIFF
--- a/plugin/mru.vim
+++ b/plugin/mru.vim
@@ -853,7 +853,11 @@ func! s:MRU_Toggle(pat, splitdir) abort
     let winnum = bufwinnr(s:MRU_buf_name)
     if winnum != -1
         exe winnum . 'wincmd w'
-        silent! close
+        if g:MRU_Use_Current_Window && !empty(expand('#'))
+          silent! b #
+        else
+          silent! close
+        endif
     else
         call s:MRU_Cmd(a:pat, a:splitdir, '')
     endif

--- a/plugin/mru.vim
+++ b/plugin/mru.vim
@@ -648,7 +648,12 @@ func! s:MRU_Open_Window(pat, splitdir, winsz) abort
 
   " Mark the buffer as scratch
   setlocal buftype=nofile
-  setlocal bufhidden=delete
+  if g:MRU_Use_Current_Window
+    " avoid using mru buffer as alternate file
+    setlocal bufhidden=wipe
+  else
+    setlocal bufhidden=delete
+  endif
   setlocal noswapfile
   setlocal nobuflisted
   setlocal nowrap


### PR DESCRIPTION
WIP, no tests added, but some further tweaks following on from https://github.com/yegappan/mru/pull/50...

In addition to keeping the alternate file when opening/viewing file from the MRU files window, also:

* Update MRUToggle command to just switch back to the previous buffer rather than close the window when MRU set to use the current window, otherwise we end up closing windows unexpectedly.
* Wipe the MRU buffer on hide when MRU set to the use the current window, otherwise the empty MRU buffer can be set as the alternate file, and switching back to an empty buffer, even accidentally, isn't helpful.

These changes are working well for me, but that does not mean they are correct ;-) 