### PR TITLE
Do not useopen when MRU set to use current window

### DIFF
--- a/plugin/mru.vim
+++ b/plugin/mru.vim
@@ -430,7 +430,7 @@ func! s:MRU_Window_Edit_File(fname, multi, edit_type, open_type) abort
     " If the selected file is already open in one of the windows,
     " jump to it
     let winnum = bufwinnr('^' . a:fname . '$')
-    if winnum != -1
+    if winnum != -1 && g:MRU_Use_Current_Window == 0
       exe winnum . 'wincmd w'
     else
       if g:MRU_Auto_Close == 1 && g:MRU_Use_Current_Window == 0

--- a/test/unit_tests.vim
+++ b/test/unit_tests.vim
@@ -1754,6 +1754,30 @@ func Test_59()
 endfunc
 
 " ==========================================================================
+" Test60
+" With MRU_Use_Current_Window set to 1, MRU opens a selected file in the
+" current window, even when the file is already open in another window
+" ==========================================================================
+func Test_60()
+  let test_name = 'test60'
+  let g:MRU_Use_Current_Window = 1
+
+  edit file1.txt
+  only
+  below split file2.txt
+
+  MRU
+  call search('file1.txt')
+  exe "normal \<Enter>"
+
+  if winnr() == 2
+    call LogResult(test_name, "pass")
+  else
+    call LogResult(test_name, "FAIL")
+  endif
+endfunc
+
+" ==========================================================================
 
 " Create the files used by the tests
 call writefile(['MRU test file1'], 'file1.txt')


### PR DESCRIPTION
When MRU is set to open in the current window, open a selected file
in the current window, even if it is already open in another window.

Note that this matches the behaviour of other plugins like Netrw and
bufexplorer when they are configured to open in the current window.

This commit does not change the behaviour for opening multiple files,
though it also doesn't add any tests to assert that, maybe it should?