### PR TITLE
Use global fzf window layout for FZFMru command

### DIFF
--- a/plugin/mru.vim
+++ b/plugin/mru.vim
@@ -1074,8 +1074,7 @@ func s:MRU_FZF_Run() abort
 
   call fzf#run(fzf#wrap({'source' : s:MRU_files,
     \ 'options' : '--no-sort',
-    \ 'sink' : function('s:MRU_FZF_EditFile'),
-    \ 'down' : g:MRU_Window_Height}, 0))
+    \ 'sink' : function('s:MRU_FZF_EditFile')}, 0))
 endfunc
 command! -nargs=0 FZFMru call s:MRU_FZF_Run()
 


### PR DESCRIPTION
It seems odd to load FZFMru with a different layout to other FZF
commands, so remove the down option override when calling fzf#wrap.

I think I understand why this was added, it makes the FZFMru window the
same layout as other MRU windows (when not set to use current window),
but this really isn't an MRU window, it's a FZF window with MRU files.