### PR TITLE
Add option to open file using relative path

### DIFF
--- a/doc/mru.txt
+++ b/doc/mru.txt
@@ -269,6 +269,7 @@ file. A summary of these variables is below:
   |MRU_Use_Current_Window|	use current window to display MRU list
   |MRU_Auto_Close|		close the MRU window when a file is selected
   |MRU_Window_Open_Always|	open the MRU window even for a single file
+  |MRU_Open_File_Relative|	open files using relative paths
   |MRU_Open_File_Use_Tabs|	open files in separate tab pages
   |MRU_FuzzyMatch|		use fuzzy match for filtering file names
   |MRU_Add_Menu|		add MRU files to the "Recent Files" menu
@@ -358,6 +359,14 @@ directly opened. To force open the MRU window always, you can set the
 MRU_Window_Open_Always variable to 1. By default this variable is set to 0.
 >
 	let MRU_Window_Open_Always = 1
+<
+						*MRU_Open_File_Relative*
+When opening a file from the MRU list, the file is normally opened using the
+path shown in the list, which defaults to the full path. To always try and
+open files relative to the home directory or current directory, you can set
+the MRU_Open_File_Relative variable to 1. By default this is set to 0.
+>
+	let MRU_Open_File_Relative = 1
 <
 						*MRU_Open_File_Use_Tabs*
 When opening a file from the MRU list, the file is opened in the current

--- a/plugin/mru.vim
+++ b/plugin/mru.vim
@@ -56,6 +56,10 @@ if !exists('MRU_Auto_Close')
   let MRU_Auto_Close = 1
 endif
 
+if !exists("MRU_Open_File_Relative ")
+  let MRU_Open_File_Relative = 0
+endif
+
 if !exists('g:MRU_File')
   if has('unix') || has('macunix')
     let s:MRU_File = $HOME . '/.vim_mru_files'
@@ -555,6 +559,11 @@ func! s:MRU_Select_File_Cmd(opt) range abort
 
     " The text in the MRU window contains the filename in parenthesis
     let file = matchstr(f, g:MRU_Filename_Format.parser)
+
+    if g:MRU_Open_File_Relative  == 1
+      " Open relative to home directory or current directory if possible
+      let file = fnamemodify(file, ":~:.")
+    endif
 
     call s:MRU_Window_Edit_File(file, multi, edit_type, open_type)
 

--- a/test/unit_tests.vim
+++ b/test/unit_tests.vim
@@ -1507,6 +1507,23 @@ func Test_62()
 endfunc
 
 " ==========================================================================
+" Test63
+" With MRU_Open_File_Relative set to 1, MRU opens a selected file relative to
+" the current working directory (or home directory, but that's hard to test)
+" ==========================================================================
+func Test_63()
+  let g:MRU_Open_File_Relative = 1
+  edit file1.txt
+  edit file2.txt
+  bwipe file1.txt
+  MRU
+  call search('file1.txt')
+  exe "normal \<Enter>"
+  call s:Assert_equal('file1.txt', expand('%'))
+  let g:MRU_Open_File_Relative = 0
+endfunc
+
+" ==========================================================================
 
 " Create the files used by the tests
 call writefile(['MRU test file1'], 'file1.txt')


### PR DESCRIPTION
MRU normally opens files using the path found in the MRU list, which by default shows the full path to the file. For people using the default Vim statusline or using %f in a custom statusline, this means a file opened via MRU will never been shown relative to the current directory.

This commit adds an option to modify the path before opening the file so it will be opened relative to the home directory or current directory if possible, which is also consistent with how the FZFMru command works.

There are other options here, it is possible to use MRU_Filename_Format to show relative paths, but I think having an option to open files using relative paths is much neater (the default display in the MRU files list is very nice as it is, showing relative paths here can get a bit fugly).