### PR TITLE
Update parser regex to allow parentheses in path

### DIFF
--- a/plugin/mru.vim
+++ b/plugin/mru.vim
@@ -143,7 +143,7 @@ endif
 if !exists('MRU_Filename_Format')
   let MRU_Filename_Format = {
 	\ 'formatter': 'fnamemodify(v:val, ":t") . " (" . v:val . ")"',
-	\ 'parser': '(\zs.*\ze)',
+	\ 'parser': ' (\zs\(\a:\)\=[/\\].*\ze)$',
 	\ 'syntax': '^.\{-}\ze('
 	\}
 endif

--- a/test/unit_tests.vim
+++ b/test/unit_tests.vim
@@ -1523,6 +1523,23 @@ func Test_63()
   let g:MRU_Open_File_Relative = 0
 endfunc
 
+" ===================================================================
+" Test64
+" Test opening files with parentheses in the path, unusual, but valid
+" ===================================================================
+func Test_64()
+  call writefile(['MRU test file with parenthesis'], 'file(1).txt')
+  edit file(1).txt
+  let l:file1_path = expand('%:p')
+  edit file2.txt
+  bwipe file(1).txt
+  MRU
+  call search('file(1).txt')
+  exe "normal \<Enter>"
+  call s:Assert_equal(l:file1_path, expand('%:p'))
+  call delete('file(1).txt')
+endfunc
+
 " ==========================================================================
 
 " Create the files used by the tests


### PR DESCRIPTION
Update parser regex to allow files or directory names with parentheses, e.g. https://svelte.dev/docs/kit/advanced-routing#Advanced-layouts-(group)

Not tested on Windows, but regex tested with example Windows style path.